### PR TITLE
Change triggers

### DIFF
--- a/scripts/hangops-jobbot.coffee
+++ b/scripts/hangops-jobbot.coffee
@@ -5,6 +5,6 @@ module.exports = (robot) ->
     robot.logger.debug "Received Google document remind message will remind #{res.message.text}"
     res.send "If you haven't already, feel free to pin your Job Description and add it to the Google Doc listed in the topic ---^"
 
-  robot.hear /looking for|candidate|to hire/i, (res) ->
+  robot.hear /is hiring|to hire/i, (res) ->
     robot.logger.debug "I heard: #{res.message.text} - so I'll remind now"
     res.reply "If you haven't already, feel free to pin your Job Description and add it to the Google Doc listed in the topic ---^"


### PR DESCRIPTION
'looking for|candidate' is triggering constantly on phrases like 'im just saying how we’ve found good candidates' and 'I have to update my job posting - we’re looking for more of a sysadmin type at this point than a developer type'. 'is hiring' seems more prevalent.

This may under-trigger the bot, but I think that's better that over-triggering it.