### PR TITLE
Turn down log level and bump cookbook version

### DIFF
--- a/cookbooks/hangops-jobbot/metadata.rb
+++ b/cookbooks/hangops-jobbot/metadata.rb
@@ -21,7 +21,7 @@ maintainer_email 'sntxrr+github@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures hangops-jobbot'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.20'
+version          '0.0.21'
 
 depends 'git', '~> 6.0.0'
 depends 'nodejs', '~> 3.0.0'

--- a/cookbooks/hangops-jobbot/recipes/default.rb
+++ b/cookbooks/hangops-jobbot/recipes/default.rb
@@ -71,7 +71,7 @@ varapikey = data_bag_item('slackapikey', node.chef_environment)
 # set some ENV vars for RUNIT
 node.override['hangops-jobbot']['config'] = {
   'HUBOT_SLACK_TOKEN' => varapikey['key'],
-  'HUBOT_LOG_LEVEL' => 'debug',
+  'HUBOT_LOG_LEVEL' => 'info',
   'REDIS_URL' => 'redis://127.0.0.1:6379/hangops-jobbot',
   'HUBOT_SLACK_BOTNAME' => 'hangops-jobbot',
   'HUBOT_SLACK_TEAM' => 'hangops',


### PR DESCRIPTION
-- we don't need the debug messages currently
-- turning them down and bumping cookbook version