### PR TITLE
ignore threads when responding to messages

### DIFF
--- a/scripts/hangops-jobbot.coffee
+++ b/scripts/hangops-jobbot.coffee
@@ -2,11 +2,8 @@ module.exports = (robot) ->
 
   robot.hear /is hiring|to hire|re hiring|is looking for|am hiring/i, (res) ->
     robot.logger.debug "I heard: #{res.message.text} - so I'll remind in a DM now"
-    if res.message.thread_ts?
-      # The incoming message was inside a thread, responding normally will continue the thread
-      res.send "If you haven't already, feel free to pin your job description and add it via the Google form listed in the topic ---^\n(I've included a direct link for your convenience: https://bit.ly/2Iv436W)\nView jobs at: https://bit.ly/2EsFzXS"
-    else
-      # The incoming message was not inside a thread, so lets respond by creating a new thread
+    if !res.message.thread_ts?
+      # The incoming message was not inside a thread, so lets respond by creating a new thread. We will ignore messages inside threads
       res.message.thread_ts = res.message.rawMessage.ts
       res.send "If you haven't already, feel free to pin your job description and add it via the Google form listed in the topic ---^\n(I've included a direct link for your convenience: https://bit.ly/2Iv436W)\nView jobs at: https://bit.ly/2EsFzXS"
 


### PR DESCRIPTION
don't ever reply inside of an existing thread.
Unless I'm missing something, there should never be a need to respond to messages inside of threads. If one is posting a job posting for the first time, which would be outside a thread, the reminder is helpful. Once inside a thread, one is probably either discussing something or just posting additional jobs, making the reminder redundant. 